### PR TITLE
feat(metadata): add admin update functions for colors & backgrounds

### DIFF
--- a/src/MetadataRenderer.sol
+++ b/src/MetadataRenderer.sol
@@ -229,4 +229,8 @@ contract MetadataRenderer is IMetadataRenderer, Ownable {
     function updateWeatherColor(string calldata weather, string calldata color) external onlyOwner {
         weatherColors[weather] = color;
     }
+
+    function updateTimeColor(string calldata timeOfDay, string calldata color) external onlyOwner {
+        timeColors[timeOfDay] = color;
+    }
 }

--- a/src/MetadataRenderer.sol
+++ b/src/MetadataRenderer.sol
@@ -222,4 +222,11 @@ contract MetadataRenderer is IMetadataRenderer, Ownable {
             )
         );
     }
+
+        /**
+     * @dev Update color scheme (only owner)
+     */
+    function updateWeatherColor(string calldata weather, string calldata color) external onlyOwner {
+        weatherColors[weather] = color;
+    }
 }

--- a/src/MetadataRenderer.sol
+++ b/src/MetadataRenderer.sol
@@ -233,4 +233,8 @@ contract MetadataRenderer is IMetadataRenderer, Ownable {
     function updateTimeColor(string calldata timeOfDay, string calldata color) external onlyOwner {
         timeColors[timeOfDay] = color;
     }
+
+    function updateWeatherBackground(string calldata weather, string calldata background) external onlyOwner {
+        weatherBackgrounds[weather] = background;
+    }
 }

--- a/src/MetadataRenderer.sol
+++ b/src/MetadataRenderer.sol
@@ -223,7 +223,7 @@ contract MetadataRenderer is IMetadataRenderer, Ownable {
         );
     }
 
-        /**
+    /**
      * @dev Update color scheme (only owner)
      */
     function updateWeatherColor(string calldata weather, string calldata color) external onlyOwner {

--- a/src/interfaces/IDataOracle.sol
+++ b/src/interfaces/IDataOracle.sol
@@ -1,6 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.19;
 
+/**
+ * @title IDataOracle
+ * @dev Interface for data oracle contracts
+ */
 interface IDataOracle {
     function getData() external view returns (string memory);
 }

--- a/src/onchain/TestDynamicNFT.sol
+++ b/src/onchain/TestDynamicNFT.sol
@@ -29,8 +29,10 @@ contract TestDynamicNFT is ERC721 {
     event NFTUpdated(uint256 indexed tokenId, string updateType, string newValue);
 
     // Predefined weather and time options for testing
-    string[] private weatherOptions = ["sunny", "rainy", "cloudy", "snowy", "foggy", "stormy", "windy", "hail", "hurricane"];
-    string[] private timeOptions = ["morning", "afternoon", "evening", "night", "midnight", "dusk", "aurora", "twilight"];
+    string[] private weatherOptions =
+        ["sunny", "rainy", "cloudy", "snowy", "foggy", "stormy", "windy", "hail", "hurricane"];
+    string[] private timeOptions =
+        ["morning", "afternoon", "evening", "night", "midnight", "dusk", "aurora", "twilight"];
 
     constructor() ERC721("Simple Dynamic NFT", "SDYNFT") {}
 


### PR DESCRIPTION
# PR Description
## Summary
Enhances the `MetadataRenderer` contract with external admin-only update functions for dynamic metadata styling and improves documentation across interfaces.

### What's Changed
- **MetadataRenderer**
  - Added `updateWeatherColor(weather, color)` → update weather-based color schemes
  - Added `updateTimeColor(timeOfDay, color)` → update time-of-day color schemes
  - Added `updateWeatherBackground(weather, background)` → update weather-based backgrounds
- **IDataOracle**
  - Added NatSpec title and dev comments for clarity
- **TestDynamicNFT**
  - Code formatting (`forge fmt`) applied for cleaner readability

### Why
- Provides greater flexibility for updating dynamic NFT rendering parameters.
- Improves developer experience with clearer NatSpec documentation.
- Maintains consistent formatting across contracts.

### Impact
- **OnlyOwner functions**: restricted to contract admin, no effect on end-users.
- Safe updates to metadata visuals without redeploying contracts.
